### PR TITLE
Add a route so the file can be actually downloaded by the browser

### DIFF
--- a/file_encrypt.routing.yml
+++ b/file_encrypt.routing.yml
@@ -1,0 +1,7 @@
+file_encrypt.file_download:
+  path: '/encrypt/files/{scheme}'
+  defaults:
+    _controller: \Drupal\system\FileDownloadController::download
+    scheme: encrypt
+  requirements:
+    _access: 'TRUE'

--- a/file_encrypt.services.yml
+++ b/file_encrypt.services.yml
@@ -1,0 +1,9 @@
+services:
+  stream_wrapper.encrypt:
+    class: \Drupal\file_encrypt\EncryptStreamWrapper
+    tags:
+      - { name: stream_wrapper, scheme: encrypt }
+  path_processor.encrypt_files:
+    class: \Drupal\file_encrypt\PathProcessor\PathProcessorFiles
+    tags:
+      - { name: path_processor_inbound, priority: 200 }

--- a/src/EncryptStreamWrapper.php
+++ b/src/EncryptStreamWrapper.php
@@ -69,7 +69,7 @@ class EncryptStreamWrapper extends LocalStream {
    */
   public function getExternalUrl() {
     $path = str_replace('\\', '/', $this->getTarget());
-    return Url::fromRoute('system.encrypted_file_download', ['filepath' => $path], ['absolute' => TRUE])
+    return Url::fromRoute('file_encrypt.file_download', ['filepath' => $path], ['absolute' => TRUE])
       ->toString(TRUE)->getGeneratedUrl();
   }
 

--- a/src/EncryptStreamWrapper.php
+++ b/src/EncryptStreamWrapper.php
@@ -68,8 +68,9 @@ class EncryptStreamWrapper extends LocalStream {
    * {@inheritdoc}
    */
   public function getExternalUrl() {
+    $profile = $this->extractEncryptionProfile($this->uri);
     $path = str_replace('\\', '/', $this->getTarget());
-    return Url::fromRoute('file_encrypt.file_download', ['filepath' => $path], ['absolute' => TRUE])
+    return Url::fromRoute('file_encrypt.file_download', ['file' => $profile->id() . '/' . $path], ['absolute' => TRUE])
       ->toString(TRUE)->getGeneratedUrl();
   }
 

--- a/src/PathProcessor/PathProcessorFiles.php
+++ b/src/PathProcessor/PathProcessorFiles.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\file_encrypt\PathProcessor;
+
+use Drupal\Core\PathProcessor\InboundPathProcessorInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Defines a path processor to rewrite file URLs.
+ *
+ * As the route system does not allow arbitrary amount of parameters convert
+ * the file path to a query parameter on the request.
+ */
+class PathProcessorFiles implements InboundPathProcessorInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processInbound($path, Request $request) {
+    if (strpos($path, '/encrypt/files/') === 0 && !$request->query->has('file')) {
+      $file_path = preg_replace('|^\/encrypt\/files\/|', '', $path);
+      $request->query->set('file', $file_path);
+      return '/encrypt/files';
+    }
+    return $path;
+  }
+
+}

--- a/tests/src/Kernel/EncryptStreamTest.php
+++ b/tests/src/Kernel/EncryptStreamTest.php
@@ -5,11 +5,18 @@ namespace Drupal\Tests\file_encrypt\Kernel;
 use Drupal\file_encrypt\EncryptStreamWrapper;
 
 /**
+ * Tests the encryption stream wrapper.
+ *
  * @group file_encrypt
+ *
+ * @see \Drupal\file_encrypt\EncryptStreamWrapper
  */
 class EncryptStreamTest extends FileEncryptTestBase {
 
-  public function testDecrypt() {
+  /**
+   * Tests the stream wrapper using a non streaming encryption method.
+   */
+  public function testNonStreamingEncryption() {
     $this->assertFalse(file_exists('vfs://root/encrypt_test/example.txt'));
     $this->assertFalse(file_exists(EncryptStreamWrapper::SCHEME . '://encryption_profile_1/example.txt'));
 

--- a/tests/src/Kernel/EncryptStreamTest.php
+++ b/tests/src/Kernel/EncryptStreamTest.php
@@ -2,116 +2,12 @@
 
 namespace Drupal\Tests\file_encrypt\Kernel;
 
-use Drupal\Core\DependencyInjection\ContainerBuilder;
-use Drupal\Core\Site\Settings;
-use Drupal\encrypt\Entity\EncryptionProfile;
 use Drupal\file_encrypt\EncryptStreamWrapper;
-use Drupal\KernelTests\KernelTestBase;
-use Drupal\key\Entity\Key;
 
 /**
  * @group file_encrypt
  */
-class EncryptStreamTest extends KernelTestBase {
-
-  /**
-   * {@inheritdoc}
-   */
-  public static $modules = ['file_encrypt', 'encrypt', 'key', 'encrypt_test'];
-
-  /**
-   * A list of testkeys.
-   *
-   * @var \Drupal\key\Entity\Key[]
-   */
-  protected $testKeys;
-
-  /**
-   * A list of test encryption profiles.
-   *
-   * @var \Drupal\encrypt\Entity\EncryptionProfile[]
-   */
-  protected $encryptionProfiles;
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function setUp() {
-    parent::setUp();
-
-    $this->createTestKeys();
-    $this->createTestEncryptionProfiles();
-
-    mkdir('vfs://root/encrypt_test');
-    $settings = Settings::getInstance() ? Settings::getAll() : [];
-    $settings['encrypted_file_path'] = 'vfs://root/encrypt_test';
-    new Settings($settings);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function register(ContainerBuilder $container) {
-    parent::register($container);
-
-    $container->register('stream_wrapper.' . EncryptStreamWrapper::SCHEME, EncryptStreamWrapper::class)
-      ->addTag('stream_wrapper', ['scheme' => EncryptStreamWrapper::SCHEME]);
-  }
-
-  /**
-   * Creates test keys for usage in tests.
-   */
-  protected function createTestKeys() {
-    // Create a 128bit testkey.
-    $key_128 = Key::create([
-      'id' => 'testing_key_128',
-      'label' => 'Testing Key 128 bit',
-      'key_type' => "encryption",
-      'key_type_settings' => ['key_size' => '128'],
-      'key_provider' => 'config',
-      'key_provider_settings' => ['key_value' => 'mustbesixteenbit'],
-    ]);
-    $key_128->save();
-    $this->testKeys['testing_key_128'] = $key_128;
-
-    // Create a 256bit testkey.
-    $key_256 = Key::create([
-      'id' => 'testing_key_256',
-      'label' => 'Testing Key 256 bit',
-      'key_type' => "encryption",
-      'key_type_settings' => ['key_size' => '256'],
-      'key_provider' => 'config',
-      'key_provider_settings' => ['key_value' => 'mustbesixteenbitmustbesixteenbit'],
-    ]);
-    $key_256->save();
-    $this->testKeys['testing_key_256'] = $key_256;
-  }
-
-  /**
-   * Creates test encryption profiles for usage in tests.
-   */
-  protected function createTestEncryptionProfiles() {
-    // Create test encryption profiles.
-    $encryption_profile_1 = EncryptionProfile::create([
-      'id' => 'encryption_profile_1',
-      'label' => 'Encryption profile 1',
-      'encryption_method' => 'test_encryption_method',
-      'encryption_key' => $this->testKeys['testing_key_128']->id(),
-    ]);
-    $encryption_profile_1->save();
-    $this->encryptionProfiles['encryption_profile_1'] = $encryption_profile_1;
-
-    $encryption_profile_2 = EncryptionProfile::create([
-      'id' => 'encryption_profile_2',
-      'label' => 'Encryption profile 2',
-      'encryption_method' => 'config_test_encryption_method',
-      'encryption_method_configuration' => ['mode' => 'CFB'],
-      'encryption_key' => $this->testKeys['testing_key_256']->id(),
-    ]);
-    $encryption_profile_2->save();
-    $this->encryptionProfiles['encryption_profile_2'] = $encryption_profile_2;
-  }
-
+class EncryptStreamTest extends FileEncryptTestBase {
 
   public function testDecrypt() {
     $this->assertFalse(file_exists('vfs://root/encrypt_test/example.txt'));

--- a/tests/src/Kernel/EncryptStreamWrapperTest.php
+++ b/tests/src/Kernel/EncryptStreamWrapperTest.php
@@ -27,4 +27,25 @@ class EncryptStreamWrapperTest extends FileEncryptTestBase {
     $this->assertEquals('test-data', $content);
   }
 
+  public function testWithMissingFolder() {
+    $this->assertFalse(file_exists('vfs://root/encrypt_test/folder/example.txt'));
+    $this->assertFalse(file_exists(EncryptStreamWrapper::SCHEME . '://encryption_profile_1/folder/example.txt'));
+
+    // The folder doesn't exist yet.
+    $this->setExpectedException(\PHPUnit_Framework_Error_Warning::class);
+    file_put_contents(EncryptStreamWrapper::SCHEME . '://encryption_profile_1/folder/example.txt', 'test-data');
+  }
+
+  public function testWithFolder() {
+    $this->assertFalse(file_exists('vfs://root/encrypt_test/folder/example.txt'));
+    $this->assertFalse(file_exists(EncryptStreamWrapper::SCHEME . '://encryption_profile_1/folder/example.txt'));
+
+    mkdir(EncryptStreamWrapper::SCHEME . '://encryption_profile_1/folder');
+    file_put_contents(EncryptStreamWrapper::SCHEME . '://encryption_profile_1/folder/example.txt', 'test-data');
+    $this->assertNotEquals('test-data', file_get_contents('vfs://root/encrypt_test/folder/example.txt'));
+
+    $content = file_get_contents(EncryptStreamWrapper::SCHEME . '://encryption_profile_1/folder/example.txt');
+    $this->assertEquals('test-data', $content);
+  }
+
 }

--- a/tests/src/Kernel/EncryptStreamWrapperTest.php
+++ b/tests/src/Kernel/EncryptStreamWrapperTest.php
@@ -11,7 +11,7 @@ use Drupal\file_encrypt\EncryptStreamWrapper;
  *
  * @see \Drupal\file_encrypt\EncryptStreamWrapper
  */
-class EncryptStreamTest extends FileEncryptTestBase {
+class EncryptStreamWrapperTest extends FileEncryptTestBase {
 
   /**
    * Tests the stream wrapper using a non streaming encryption method.

--- a/tests/src/Kernel/FileEncryptDownloadTest.php
+++ b/tests/src/Kernel/FileEncryptDownloadTest.php
@@ -6,6 +6,11 @@ use Drupal\file\Entity\File;
 use Drupal\file_encrypt\EncryptStreamWrapper;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * Tests downloading an encrypted file via HTTP.
+ *
+ * @group file_encrypt
+ */
 class FileEncryptDownloadTest extends FileEncryptTestBase {
 
   /**
@@ -37,6 +42,9 @@ class FileEncryptDownloadTest extends FileEncryptTestBase {
     ])->save();
   }
 
+  /**
+   * Tests a file download via HTTP.
+   */
   public function testFileDownloadViaHttp() {
     $request = Request::create('/encrypt/files/encryption_profile_1/example.txt');
     /** @var \Symfony\Component\HttpKernel\HttpKernelInterface $http_kernel */

--- a/tests/src/Kernel/FileEncryptDownloadTest.php
+++ b/tests/src/Kernel/FileEncryptDownloadTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\Tests\file_encrypt\Kernel;
+
+use Drupal\file\Entity\File;
+use Drupal\file_encrypt\EncryptStreamWrapper;
+use Symfony\Component\HttpFoundation\Request;
+
+class FileEncryptDownloadTest extends FileEncryptTestBase {
+
+  /**
+   * The encrypted URI.
+   *
+   * @var string
+   */
+  protected $encryptedUri;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = ['file', 'user'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->installEntitySchema('file');
+    $this->installSchema('file', 'file_usage');
+
+    $uri = EncryptStreamWrapper::SCHEME . '://encryption_profile_1/example.txt';
+    file_put_contents($uri, 'test-data');
+    $this->encryptedUri = $uri;
+    File::create([
+      'uri' => $this->encryptedUri,
+    ])->save();
+  }
+
+  public function testFileDownloadViaHttp() {
+    $request = Request::create('/encrypt/files/encryption_profile_1/example.txt');
+    /** @var \Symfony\Component\HttpKernel\HttpKernelInterface $http_kernel */
+    $http_kernel = $this->container->get('http_kernel');
+
+    $response = $http_kernel->handle($request);
+    $this->assertEquals(200, $response->getStatusCode());
+
+
+    ob_start();
+    $response->send();
+    $out = ob_get_contents();
+    ob_end_clean();
+    // @fixme This doesn't yet catch the actual response.
+  }
+
+}

--- a/tests/src/Kernel/FileEncryptTestBase.php
+++ b/tests/src/Kernel/FileEncryptTestBase.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Drupal\Tests\file_encrypt\Kernel;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Site\Settings;
+use Drupal\encrypt\Entity\EncryptionProfile;
+use Drupal\file_encrypt\EncryptStreamWrapper;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\key\Entity\Key;
+
+abstract class FileEncryptTestBase extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = ['file_encrypt', 'encrypt', 'key', 'encrypt_test'];
+
+  /**
+   * A list of testkeys.
+   *
+   * @var \Drupal\key\Entity\Key[]
+   */
+  protected $testKeys;
+
+  /**
+   * A list of test encryption profiles.
+   *
+   * @var \Drupal\encrypt\Entity\EncryptionProfile[]
+   */
+  protected $encryptionProfiles;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->createTestKeys();
+    $this->createTestEncryptionProfiles();
+
+    mkdir('vfs://root/encrypt_test');
+    $settings = Settings::getInstance() ? Settings::getAll() : [];
+    $settings['encrypted_file_path'] = 'vfs://root/encrypt_test';
+    new Settings($settings);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function register(ContainerBuilder $container) {
+    parent::register($container);
+
+    $container->register('stream_wrapper.' . EncryptStreamWrapper::SCHEME, EncryptStreamWrapper::class)
+      ->addTag('stream_wrapper', ['scheme' => EncryptStreamWrapper::SCHEME]);
+  }
+
+  /**
+   * Creates test keys for usage in tests.
+   */
+  protected function createTestKeys() {
+    // Create a 128bit testkey.
+    $key_128 = Key::create([
+      'id' => 'testing_key_128',
+      'label' => 'Testing Key 128 bit',
+      'key_type' => "encryption",
+      'key_type_settings' => ['key_size' => '128'],
+      'key_provider' => 'config',
+      'key_provider_settings' => ['key_value' => 'mustbesixteenbit'],
+    ]);
+    $key_128->save();
+    $this->testKeys['testing_key_128'] = $key_128;
+
+    // Create a 256bit testkey.
+    $key_256 = Key::create([
+      'id' => 'testing_key_256',
+      'label' => 'Testing Key 256 bit',
+      'key_type' => "encryption",
+      'key_type_settings' => ['key_size' => '256'],
+      'key_provider' => 'config',
+      'key_provider_settings' => ['key_value' => 'mustbesixteenbitmustbesixteenbit'],
+    ]);
+    $key_256->save();
+    $this->testKeys['testing_key_256'] = $key_256;
+  }
+
+  /**
+   * Creates test encryption profiles for usage in tests.
+   */
+  protected function createTestEncryptionProfiles() {
+    // Create test encryption profiles.
+    $encryption_profile_1 = EncryptionProfile::create([
+      'id' => 'encryption_profile_1',
+      'label' => 'Encryption profile 1',
+      'encryption_method' => 'test_encryption_method',
+      'encryption_key' => $this->testKeys['testing_key_128']->id(),
+    ]);
+    $encryption_profile_1->save();
+    $this->encryptionProfiles['encryption_profile_1'] = $encryption_profile_1;
+
+    $encryption_profile_2 = EncryptionProfile::create([
+      'id' => 'encryption_profile_2',
+      'label' => 'Encryption profile 2',
+      'encryption_method' => 'config_test_encryption_method',
+      'encryption_method_configuration' => ['mode' => 'CFB'],
+      'encryption_key' => $this->testKeys['testing_key_256']->id(),
+    ]);
+    $encryption_profile_2->save();
+    $this->encryptionProfiles['encryption_profile_2'] = $encryption_profile_2;
+  }
+
+
+}

--- a/tests/src/Kernel/FileEncryptTestBase.php
+++ b/tests/src/Kernel/FileEncryptTestBase.php
@@ -9,6 +9,9 @@ use Drupal\file_encrypt\EncryptStreamWrapper;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\key\Entity\Key;
 
+/**
+ * Base test class for all kind of file encrypt tests.
+ */
 abstract class FileEncryptTestBase extends KernelTestBase {
 
   /**

--- a/tests/src/Unit/PathProcessorFilesTest.php
+++ b/tests/src/Unit/PathProcessorFilesTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\Tests\file_encrypt\Unit;
+
+use Drupal\file_encrypt\PathProcessor\PathProcessorFiles;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @coversDefaultClass \Drupal\file_encrypt\PathProcessor\PathProcessorFiles
+ * @group file_encrypt
+ */
+class PathProcessorFilesTest extends \PHPUnit_Framework_TestCase {
+
+  /**
+   * @dataProvider providerTestProcessInbound
+   */
+  public function testProcessInbound($incoming_path, Request $incoming_request, $expected_path, $expected_file_path = NULL) {
+    $processor = new PathProcessorFiles();
+    $result = $processor->processInbound($incoming_path, $incoming_request);
+    $this->assertEquals($expected_path, $result);
+
+    if (isset($expected_file_path)) {
+      $this->assertEquals($expected_file_path, $incoming_request->query->get('file'));
+    }
+    else {
+      $this->assertFalse($incoming_request->query->has('file'));
+    }
+  }
+
+  /**
+   * @see \Drupal\Tests\file_encrypt\Unit\PathProcessorFilesTest::testProcessInbound
+   */
+  public function providerTestProcessInbound() {
+    $data = [];
+    $data['non-file-path'] = ['/my-path', Request::create('/my-path'), '/my-path'];
+    $data['encrypt-file-path'] = ['/encrypt/files/test.txt', Request::create('/encrypt/files/test.txt'), '/encrypt/files', 'test.txt'];
+    $data['encrypt-file-path-with-folder'] = ['/encrypt/files/folder_a/folder_b/test.txt', Request::create('/encrypt/files/folder_a/folder_b/test.txt'), '/encrypt/files', 'folder_a/folder_b/test.txt'];
+    $request = Request::create('/encrypt/files/test.txt');
+    $request->query->set('file', 'test.txt');
+    $data['encrypt-file-already-processed'] = ['/encrypt/files/test.txt', $request, '/encrypt/files/test.txt', 'test.txt'];
+    return $data;
+  }
+
+}


### PR DESCRIPTION
Followup of #2

This PR adds a route + route processor so we can link to the file directly,
and the browser can finally download it.

The test doesn't yet work, some hand on the `ob_start()` / `ob_get_contents()` ...
could be really helpful.
