### PR TITLE
Integrate file_encrypt into file fields.

### DIFF
--- a/config/schema/file_encrypt.schema.yml
+++ b/config/schema/file_encrypt.schema.yml
@@ -1,0 +1,7 @@
+field.storage.*.*.third_party.file_encrypt:
+  type: mapping
+  label: 'File encrypt setting'
+  mapping:
+    encryption_profile:
+      type: string
+      label: 'Encryption profile'

--- a/file_encrypt.module
+++ b/file_encrypt.module
@@ -5,6 +5,7 @@
  * Provides the necessary hooks for the file_encrypt module.
  */
 
+use Drupal\Core\Field\FieldConfigInterface;
 use Drupal\field\FieldStorageConfigInterface;
 use Drupal\file_encrypt\EncryptStreamWrapper;
 use Drupal\file_encrypt\Hooks\FieldStorageConfigEditFormAlter;
@@ -40,6 +41,24 @@ function file_encrypt_field_storage_config_presave(FieldStorageConfigInterface $
         $field_config->setSetting('file_directory', $encryption_profile . '/' . $file_directory);
         $field_config_storage->save($field_config);
       }
+    }
+  }
+}
+
+/**
+ * Implements hook_field_config_presave().
+ */
+function file_encrypt_field_config_presave(FieldConfigInterface $field_config) {
+  // Add the encryption profile to the destination directory, so the stream
+  // wrapper gets the encryption profile passed along.
+  /** @var \Drupal\field\FieldStorageConfigInterface $field_storage_config */
+  $field_storage_config = $field_config->getFieldStorageDefinition();
+  if ($field_storage_config->getSetting('uri_scheme') === EncryptStreamWrapper::SCHEME) {
+    $encryption_profile = $field_storage_config->getThirdPartySetting('file_encrypt', 'encryption_profile');
+    // Ensure that destination directory starts with the encryption profile.
+    $file_directory = $field_config->getSetting('file_directory');
+    if (strpos($file_directory, $encryption_profile . '/') !== 0) {
+      $field_config->setSetting('file_directory', $encryption_profile . '/' . $file_directory);
     }
   }
 }

--- a/file_encrypt.module
+++ b/file_encrypt.module
@@ -37,7 +37,7 @@ function file_encrypt_field_storage_config_presave(FieldStorageConfigInterface $
     foreach ($field_configs as $field_config) {
       $file_directory = $field_config->getSetting('file_directory');
       // Ensure that destination directory starts with the encryption profile.
-      if (strpos($file_directory, $encryption_profile . '/') !== 0) {
+      if (strpos($file_directory, $encryption_profile) !== 0) {
         $field_config->setSetting('file_directory', $encryption_profile . '/' . $file_directory);
         $field_config_storage->save($field_config);
       }
@@ -57,7 +57,7 @@ function file_encrypt_field_config_presave(FieldConfigInterface $field_config) {
     $encryption_profile = $field_storage_config->getThirdPartySetting('file_encrypt', 'encryption_profile');
     // Ensure that destination directory starts with the encryption profile.
     $file_directory = $field_config->getSetting('file_directory');
-    if (strpos($file_directory, $encryption_profile . '/') !== 0) {
+    if (strpos($file_directory, $encryption_profile) !== 0) {
       $field_config->setSetting('file_directory', $encryption_profile . '/' . $file_directory);
     }
   }

--- a/file_encrypt.module
+++ b/file_encrypt.module
@@ -1,4 +1,8 @@
 <?php
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\field\FieldConfigInterface;
+use Drupal\field\FieldStorageConfigInterface;
+use Drupal\file_encrypt\EncryptStreamWrapper;
 use Drupal\file_encrypt\Hooks\FieldStorageConfigEditFormAlter;
 
 /**
@@ -7,4 +11,22 @@ use Drupal\file_encrypt\Hooks\FieldStorageConfigEditFormAlter;
 function file_encrypt_form_field_storage_config_edit_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state) {
   (new FieldStorageConfigEditFormAlter(\Drupal::service('plugin.manager.field.field_type'), \Drupal::service('encrypt.encryption_profile.manager')))
     ->alterForm($form, $form_state);
+}
+
+/**
+ * Implements hook_field_config_presave().
+ */
+function file_encrypt_field_config_presave(FieldConfigInterface $field_config) {
+  // Add the encryption profile to the destination directory, so the stream
+  // wrapper gets the encryption profile passed along.
+  /** @var \Drupal\field\FieldStorageConfigInterface $field_storage_config */
+  $field_storage_config = $field_config->getFieldStorageDefinition();
+  if ($field_storage_config->getSetting('uri_scheme') === EncryptStreamWrapper::SCHEME) {
+    $encryption_profile = $field_storage_config->getThirdPartySetting('file_encrypt', 'encryption_profile');
+    // Ensure that destination directory starts with the encryption profile.
+    $file_directory = $field_config->getSetting('file_directory');
+    if (strpos($file_directory, $encryption_profile . '/') !== 0) {
+      $field_config->setSetting('file_directory', $encryption_profile . '/' . $file_directory);
+    }
+  }
 }

--- a/file_encrypt.module
+++ b/file_encrypt.module
@@ -1,7 +1,11 @@
 <?php
-use Drupal\Core\Entity\EntityInterface;
-use Drupal\field\FieldConfigInterface;
-use Drupal\field\FieldStorageConfigInterface;
+
+/**
+ * @file
+ * Provides the necessary hooks for the file_encrypt module.
+ */
+
+use Drupal\Core\Field\FieldConfigInterface;
 use Drupal\file_encrypt\EncryptStreamWrapper;
 use Drupal\file_encrypt\Hooks\FieldStorageConfigEditFormAlter;
 

--- a/file_encrypt.module
+++ b/file_encrypt.module
@@ -5,7 +5,7 @@
  * Provides the necessary hooks for the file_encrypt module.
  */
 
-use Drupal\Core\Field\FieldConfigInterface;
+use Drupal\field\FieldStorageConfigInterface;
 use Drupal\file_encrypt\EncryptStreamWrapper;
 use Drupal\file_encrypt\Hooks\FieldStorageConfigEditFormAlter;
 
@@ -18,19 +18,28 @@ function file_encrypt_form_field_storage_config_edit_form_alter(&$form, \Drupal\
 }
 
 /**
- * Implements hook_field_config_presave().
+ * Implements hook_field_storage_config_presave().
  */
-function file_encrypt_field_config_presave(FieldConfigInterface $field_config) {
+function file_encrypt_field_storage_config_presave(FieldStorageConfigInterface $field_storage_config) {
   // Add the encryption profile to the destination directory, so the stream
   // wrapper gets the encryption profile passed along.
-  /** @var \Drupal\field\FieldStorageConfigInterface $field_storage_config */
-  $field_storage_config = $field_config->getFieldStorageDefinition();
   if ($field_storage_config->getSetting('uri_scheme') === EncryptStreamWrapper::SCHEME) {
     $encryption_profile = $field_storage_config->getThirdPartySetting('file_encrypt', 'encryption_profile');
-    // Ensure that destination directory starts with the encryption profile.
-    $file_directory = $field_config->getSetting('file_directory');
-    if (strpos($file_directory, $encryption_profile . '/') !== 0) {
-      $field_config->setSetting('file_directory', $encryption_profile . '/' . $file_directory);
+
+    $field_config_storage = \Drupal::entityTypeManager()->getStorage('field_config');
+    $field_configs = $field_config_storage->loadMultiple($field_config_storage->getQuery()
+      ->condition('entity_type', $field_storage_config->getTargetEntityTypeId())
+      ->condition('field_name', $field_storage_config->getName())
+      ->execute());
+
+    /** @var \Drupal\Core\Field\FieldConfigInterface $field_config */
+    foreach ($field_configs as $field_config) {
+      $file_directory = $field_config->getSetting('file_directory');
+      // Ensure that destination directory starts with the encryption profile.
+      if (strpos($file_directory, $encryption_profile . '/') !== 0) {
+        $field_config->setSetting('file_directory', $encryption_profile . '/' . $file_directory);
+        $field_config_storage->save($field_config);
+      }
     }
   }
 }

--- a/file_encrypt.module
+++ b/file_encrypt.module
@@ -1,0 +1,10 @@
+<?php
+use Drupal\file_encrypt\Hooks\FieldStorageConfigEditFormAlter;
+
+/**
+ * Implements hook_form_field_storage_config_edit_form_alter().
+ */
+function file_encrypt_form_field_storage_config_edit_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state) {
+  (new FieldStorageConfigEditFormAlter(\Drupal::service('plugin.manager.field.field_type'), \Drupal::service('encrypt.encryption_profile.manager')))
+    ->alterForm($form, $form_state);
+}

--- a/src/EncryptStreamWrapper.php
+++ b/src/EncryptStreamWrapper.php
@@ -92,6 +92,8 @@ class EncryptStreamWrapper extends LocalStream {
    * {@inheritdoc}
    */
   public function dirname($uri = NULL) {
+    // This method adds the encryption profile to the URI.
+
     if (!$uri) {
       $uri = $this->uri;
     }

--- a/src/EncryptStreamWrapper.php
+++ b/src/EncryptStreamWrapper.php
@@ -69,7 +69,7 @@ class EncryptStreamWrapper extends LocalStream {
    */
   public function getExternalUrl() {
     $path = str_replace('\\', '/', $this->getTarget());
-    return Url::fromRoute('system.encrypted_file_download', ['filepath' => $path], ['absolute' => TRUE])
+    return Url::fromRoute('file_encrypt.file_download', ['filepath' => $path], ['absolute' => TRUE])
       ->toString(TRUE)->getGeneratedUrl();
   }
 

--- a/src/EncryptStreamWrapper.php
+++ b/src/EncryptStreamWrapper.php
@@ -68,8 +68,9 @@ class EncryptStreamWrapper extends LocalStream {
    * {@inheritdoc}
    */
   public function getExternalUrl() {
+    $profile = $this->extractEncryptionProfile($this->uri);
     $path = str_replace('\\', '/', $this->getTarget());
-    return Url::fromRoute('file_encrypt.file_download', ['filepath' => $path], ['absolute' => TRUE])
+    return Url::fromRoute('file_encrypt.file_download', ['file' => $profile->id() . '/' . $path], ['absolute' => TRUE])
       ->toString(TRUE)->getGeneratedUrl();
   }
 

--- a/src/EncryptStreamWrapper.php
+++ b/src/EncryptStreamWrapper.php
@@ -89,6 +89,26 @@ class EncryptStreamWrapper extends LocalStream {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function dirname($uri = NULL) {
+    if (!$uri) {
+      $uri = $this->uri;
+    }
+    $encryption_profile = parse_url($uri, PHP_URL_HOST);
+
+    list($scheme) = explode('://', $uri, 2);
+    $target = $this->getTarget($uri);
+    $dirname = dirname($target);
+
+    if ($dirname == '.') {
+      $dirname = '';
+    }
+
+    return $scheme . '://' . $encryption_profile . '/' . $dirname;
+  }
+
+  /**
    * Decrypts a given file.
    *
    * @param string $raw_file
@@ -128,13 +148,20 @@ class EncryptStreamWrapper extends LocalStream {
    * @param string $uri
    *   The URI of the encrypt URI.
    *
-   * @return \Drupal\Core\Entity\EntityInterface|\Drupal\encrypt\EncryptionProfileInterface|null
-   *   The encryption profile
+   * @return \Drupal\Core\Entity\EntityInterface|\Drupal\encrypt\EncryptionProfileInterface|null The encryption profile
+   * The encryption profile
+   *
+   * @throws \Exception
+   *   Thrown when the profile doesn't exist.
    */
   protected function extractEncryptionProfile($uri) {
     /** @var \Drupal\encrypt\EncryptionProfileManager $profile_manager */
     $profile_manager = \Drupal::service('encrypt.encryption_profile.manager');
-    return $profile_manager->getEncryptionProfile(parse_url($uri, PHP_URL_HOST));
+    $result = $profile_manager->getEncryptionProfile(parse_url($uri, PHP_URL_HOST));
+    if (!$result) {
+      throw new \Exception('Missing profile: ' . parse_url($uri, PHP_URL_HOST));
+    }
+    return $result;
   }
 
   /**

--- a/src/Hooks/FieldStorageConfigEditFormAlter.php
+++ b/src/Hooks/FieldStorageConfigEditFormAlter.php
@@ -9,6 +9,12 @@ use Drupal\encrypt\EncryptionProfileManagerInterface;
 use Drupal\field\FieldStorageConfigInterface;
 use Drupal\file\Plugin\Field\FieldType\FileItem;
 
+/**
+ * Class which implements hook_form_field_storage_config_edit_form_alter().
+ *
+ * The general idea is to change the field storage configuration form to allow
+ * storing a encryption profile when the encrypt
+ */
 class FieldStorageConfigEditFormAlter {
 
   use StringTranslationTrait;
@@ -45,8 +51,12 @@ class FieldStorageConfigEditFormAlter {
   }
 
   /**
+   * Adds the encryption_profile setting to the field storage settings form.
+   *
    * @param \Drupal\field\FieldStorageConfigInterface $field_storage_config
+   *   The field storage.
    * @param array $form
+   *   The changed form.
    */
   protected function doFormAlter(FieldStorageConfigInterface $field_storage_config, array &$form) {
     $options = $this->encryptionProfileManager->getEncryptionProfileNamesAsOptions();
@@ -72,6 +82,18 @@ class FieldStorageConfigEditFormAlter {
     $form['#entity_builders'][] = static::class . '::buildEntity';
   }
 
+  /**
+   * Builds the entity by adding the encryption_profile third party settings.
+   *
+   * @param string $entity_type_id
+   *    The entity type ID.
+   * @param \Drupal\field\FieldStorageConfigInterface $field_storage_config
+   *   The field storage configuration.
+   * @param array $form
+   *   The original form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
   public static function buildEntity($entity_type_id, FieldStorageConfigInterface $field_storage_config, $form, FormStateInterface $form_state) {
     if ($encryption_profile = $form_state->getValue(['settings', 'encryption_profile'])) {
       $field_storage_config->setThirdPartySetting('file_encrypt', 'encryption_profile', $encryption_profile);

--- a/src/Hooks/FieldStorageConfigEditFormAlter.php
+++ b/src/Hooks/FieldStorageConfigEditFormAlter.php
@@ -45,7 +45,7 @@ class FieldStorageConfigEditFormAlter {
     /** @var \Drupal\field\FieldStorageConfigInterface $field_storage_config */
     $field_storage_config = $form_state->getFormObject()->getEntity();
     $field_type_definition = $this->fieldTypeManager->getDefinition($field_storage_config->getType());
-    if (is_subclass_of($field_type_definition['class'], FileItem::class)) {
+    if (is_a($field_type_definition['class'], FileItem::class, TRUE)) {
       $this->doFormAlter($field_storage_config, $form, $form_state);
     }
   }

--- a/src/Hooks/FieldStorageConfigEditFormAlter.php
+++ b/src/Hooks/FieldStorageConfigEditFormAlter.php
@@ -6,7 +6,6 @@ use Drupal\Core\Field\FieldTypePluginManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\encrypt\EncryptionProfileManagerInterface;
-use Drupal\field\FieldConfigInterface;
 use Drupal\field\FieldStorageConfigInterface;
 use Drupal\file\Plugin\Field\FieldType\FileItem;
 
@@ -48,9 +47,8 @@ class FieldStorageConfigEditFormAlter {
   /**
    * @param \Drupal\field\FieldStorageConfigInterface $field_storage_config
    * @param array $form
-   * @param \Drupal\Core\Form\FormStateInterface $form_state
    */
-  protected function doFormAlter(FieldStorageConfigInterface $field_storage_config, array &$form, FormStateInterface $form_state) {
+  protected function doFormAlter(FieldStorageConfigInterface $field_storage_config, array &$form) {
     $options = $this->encryptionProfileManager->getEncryptionProfileNamesAsOptions();
     if (empty($options)) {
       $form['settings']['encryption_profile'] = [

--- a/src/Hooks/FieldStorageConfigEditFormAlter.php
+++ b/src/Hooks/FieldStorageConfigEditFormAlter.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\file_encrypt\Hooks;
+
+use Drupal\Core\Field\FieldTypePluginManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\encrypt\EncryptionProfileManagerInterface;
+use Drupal\field\FieldConfigInterface;
+use Drupal\field\FieldStorageConfigInterface;
+use Drupal\file\Plugin\Field\FieldType\FileItem;
+
+class FieldStorageConfigEditFormAlter {
+
+  use StringTranslationTrait;
+
+  /** @var \Drupal\Core\Field\FieldTypePluginManagerInterface */
+  protected $fieldTypeManager;
+
+  /** @var \Drupal\encrypt\EncryptionProfileManagerInterface */
+  protected $encryptionProfileManager;
+
+  /**
+   * Creates a new FieldStorageConfigEditFormAlter instance.
+   *
+   * @param \Drupal\Core\Field\FieldTypePluginManagerInterface $field_type_manager
+   *   The field type plugin manager.
+   * @param \Drupal\encrypt\EncryptionProfileManagerInterface $encryption_profile_manager
+   *   The encryption profile manager.
+   */
+  public function __construct(FieldTypePluginManagerInterface $field_type_manager, EncryptionProfileManagerInterface $encryption_profile_manager) {
+    $this->fieldTypeManager = $field_type_manager;
+    $this->encryptionProfileManager = $encryption_profile_manager;
+  }
+
+  /**
+   * Implements hook_form_field_storage_config_edit_form_alter().
+   */
+  public function alterForm(array &$form, FormStateInterface $form_state) {
+    /** @var \Drupal\field\FieldStorageConfigInterface $field_storage_config */
+    $field_storage_config = $form_state->getFormObject()->getEntity();
+    $field_type_definition = $this->fieldTypeManager->getDefinition($field_storage_config->getType());
+    if (is_subclass_of($field_type_definition['class'], FileItem::class)) {
+      $this->doFormAlter($field_storage_config, $form, $form_state);
+    }
+  }
+
+  /**
+   * @param \Drupal\field\FieldStorageConfigInterface $field_storage_config
+   * @param array $form
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   */
+  protected function doFormAlter(FieldStorageConfigInterface $field_storage_config, array &$form, FormStateInterface $form_state) {
+    $options = $this->encryptionProfileManager->getEncryptionProfileNamesAsOptions();
+    if (empty($options)) {
+      $form['settings']['encryption_profile'] = [
+        '#markup' => $this->t('No encryption profile found.'),
+      ];
+    }
+    else {
+      $form['settings']['encryption_profile'] = [
+        '#type' => 'radios',
+        '#title' => $this->t('Encryption profile'),
+        '#options' => $options,
+        '#default_value'=> $field_storage_config->getThirdPartySetting('file_encrypt', 'encryption_profile', NULL),
+        '#states' => [
+          'visible' => [
+            'input[name="settings[uri_scheme]"]' => ['value' => 'encrypt'],
+          ],
+        ],
+      ];
+    }
+
+    $form['#entity_builders'][] = static::class . '::buildEntity';
+  }
+
+  public static function buildEntity($entity_type_id, FieldStorageConfigInterface $field_storage_config, $form, FormStateInterface $form_state) {
+    if ($encryption_profile = $form_state->getValue(['settings', 'encryption_profile'])) {
+      $field_storage_config->setThirdPartySetting('file_encrypt', 'encryption_profile', $encryption_profile);
+    }
+  }
+
+}

--- a/tests/src/Functional/FieldStorageConfigurationTest.php
+++ b/tests/src/Functional/FieldStorageConfigurationTest.php
@@ -2,102 +2,16 @@
 
 namespace Drupal\Tests\file_encrypt\Functional;
 
-use Drupal\encrypt\Entity\EncryptionProfile;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
-use Drupal\key\Entity\Key;
 use Drupal\node\Entity\NodeType;
-use Drupal\Tests\BrowserTestBase;
 
 /**
  * Tests the field storage configuration UI.
  *
  * @group file_encrypt
  */
-class FieldStorageConfigurationTest extends BrowserTestBase {
-
-  /**
-   * {@inheritdoc}
-   */
-  public static $modules = ['file_encrypt', 'encrypt', 'key', 'encrypt_test', 'node', 'file', 'field_ui', 'image'];
-
-  /**
-   * A list of testkeys.
-   *
-   * @var \Drupal\key\Entity\Key[]
-   */
-  protected $testKeys;
-
-  /**
-   * A list of test encryption profiles.
-   *
-   * @var \Drupal\encrypt\Entity\EncryptionProfile[]
-   */
-  protected $encryptionProfiles;
-
-  /**
-   * Creates test keys for usage in tests.
-   */
-  protected function createTestKeys() {
-    // Create a 128bit testkey.
-    $key_128 = Key::create([
-      'id' => 'testing_key_128',
-      'label' => 'Testing Key 128 bit',
-      'key_type' => "encryption",
-      'key_type_settings' => ['key_size' => '128'],
-      'key_provider' => 'config',
-      'key_provider_settings' => ['key_value' => 'mustbesixteenbit'],
-    ]);
-    $key_128->save();
-    $this->testKeys['testing_key_128'] = $key_128;
-
-    // Create a 256bit testkey.
-    $key_256 = Key::create([
-      'id' => 'testing_key_256',
-      'label' => 'Testing Key 256 bit',
-      'key_type' => "encryption",
-      'key_type_settings' => ['key_size' => '256'],
-      'key_provider' => 'config',
-      'key_provider_settings' => ['key_value' => 'mustbesixteenbitmustbesixteenbit'],
-    ]);
-    $key_256->save();
-    $this->testKeys['testing_key_256'] = $key_256;
-  }
-
-  /**
-   * Creates test encryption profiles for usage in tests.
-   */
-  protected function createTestEncryptionProfiles() {
-    // Create test encryption profiles.
-    $encryption_profile_1 = EncryptionProfile::create([
-      'id' => 'encryption_profile_1',
-      'label' => 'Encryption profile 1',
-      'encryption_method' => 'test_encryption_method',
-      'encryption_key' => $this->testKeys['testing_key_128']->id(),
-    ]);
-    $encryption_profile_1->save();
-    $this->encryptionProfiles['encryption_profile_1'] = $encryption_profile_1;
-
-    $encryption_profile_2 = EncryptionProfile::create([
-      'id' => 'encryption_profile_2',
-      'label' => 'Encryption profile 2',
-      'encryption_method' => 'config_test_encryption_method',
-      'encryption_method_configuration' => ['mode' => 'CFB'],
-      'encryption_key' => $this->testKeys['testing_key_256']->id(),
-    ]);
-    $encryption_profile_2->save();
-    $this->encryptionProfiles['encryption_profile_2'] = $encryption_profile_2;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function setUp() {
-    parent::setUp();
-
-    $this->createTestKeys();
-    $this->createTestEncryptionProfiles();
-  }
+class FieldStorageConfigurationTest extends FunctionalTestBase {
 
   public function testFieldStorageSettingsForm() {
     $account = $this->drupalCreateUser([

--- a/tests/src/Functional/FieldStorageConfigurationTest.php
+++ b/tests/src/Functional/FieldStorageConfigurationTest.php
@@ -18,7 +18,7 @@ class FieldStorageConfigurationTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = ['file_encrypt', 'encrypt', 'key', 'encrypt_test', 'node', 'file', 'field_ui'];
+  public static $modules = ['file_encrypt', 'encrypt', 'key', 'encrypt_test', 'node', 'file', 'field_ui', 'image'];
 
   /**
    * A list of testkeys.
@@ -111,6 +111,7 @@ class FieldStorageConfigurationTest extends BrowserTestBase {
     ])->save();
 
     $assert = $this->assertSession();
+    // Test a file field.
     $this->drupalGet('admin/structure/types/manage/page/fields/add-field');
     $assert->statusCodeEquals(200);
 
@@ -120,14 +121,30 @@ class FieldStorageConfigurationTest extends BrowserTestBase {
       'label' => 'New file field',
     ], 'Save and continue');
 
-    file_put_contents('/tmp/foo.html', $this->getSession()->getPage()->getHtml());
-
     $this->submitForm([
       'settings[uri_scheme]' => 'encrypt',
       'settings[encryption_profile]' => 'encryption_profile_1',
     ], 'Save field settings');
 
     $field_storage_config = FieldStorageConfig::load('node.field_test_file');
+    $this->assertEquals('encryption_profile_1', $field_storage_config->getThirdPartySetting('file_encrypt', 'encryption_profile'));
+
+    // Test an image field.
+    $this->drupalGet('admin/structure/types/manage/page/fields/add-field');
+    $assert->statusCodeEquals(200);
+
+    $this->submitForm([
+      'new_storage_type' => 'image',
+      'field_name' => 'test_image',
+      'label' => 'New image field',
+    ], 'Save and continue');
+
+    $this->submitForm([
+      'settings[uri_scheme]' => 'encrypt',
+      'settings[encryption_profile]' => 'encryption_profile_1',
+    ], 'Save field settings');
+
+    $field_storage_config = FieldStorageConfig::load('node.field_test_image');
     $this->assertEquals('encryption_profile_1', $field_storage_config->getThirdPartySetting('file_encrypt', 'encryption_profile'));
   }
 

--- a/tests/src/Functional/FieldStorageConfigurationTest.php
+++ b/tests/src/Functional/FieldStorageConfigurationTest.php
@@ -13,6 +13,9 @@ use Drupal\node\Entity\NodeType;
  */
 class FieldStorageConfigurationTest extends FunctionalTestBase {
 
+  /**
+   * Tests the field storage adding.
+   */
   public function testFieldStorageSettingsForm() {
     $account = $this->drupalCreateUser([
       'administer content types',

--- a/tests/src/Functional/FieldStorageConfigurationTest.php
+++ b/tests/src/Functional/FieldStorageConfigurationTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Drupal\Tests\file_encrypt\Functional;
+
+use Drupal\encrypt\Entity\EncryptionProfile;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\key\Entity\Key;
+use Drupal\node\Entity\NodeType;
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests the field storage configuration UI.
+ *
+ * @group file_encrypt
+ */
+class FieldStorageConfigurationTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = ['file_encrypt', 'encrypt', 'key', 'encrypt_test', 'node', 'file', 'field_ui'];
+
+  /**
+   * A list of testkeys.
+   *
+   * @var \Drupal\key\Entity\Key[]
+   */
+  protected $testKeys;
+
+  /**
+   * A list of test encryption profiles.
+   *
+   * @var \Drupal\encrypt\Entity\EncryptionProfile[]
+   */
+  protected $encryptionProfiles;
+
+  /**
+   * Creates test keys for usage in tests.
+   */
+  protected function createTestKeys() {
+    // Create a 128bit testkey.
+    $key_128 = Key::create([
+      'id' => 'testing_key_128',
+      'label' => 'Testing Key 128 bit',
+      'key_type' => "encryption",
+      'key_type_settings' => ['key_size' => '128'],
+      'key_provider' => 'config',
+      'key_provider_settings' => ['key_value' => 'mustbesixteenbit'],
+    ]);
+    $key_128->save();
+    $this->testKeys['testing_key_128'] = $key_128;
+
+    // Create a 256bit testkey.
+    $key_256 = Key::create([
+      'id' => 'testing_key_256',
+      'label' => 'Testing Key 256 bit',
+      'key_type' => "encryption",
+      'key_type_settings' => ['key_size' => '256'],
+      'key_provider' => 'config',
+      'key_provider_settings' => ['key_value' => 'mustbesixteenbitmustbesixteenbit'],
+    ]);
+    $key_256->save();
+    $this->testKeys['testing_key_256'] = $key_256;
+  }
+
+  /**
+   * Creates test encryption profiles for usage in tests.
+   */
+  protected function createTestEncryptionProfiles() {
+    // Create test encryption profiles.
+    $encryption_profile_1 = EncryptionProfile::create([
+      'id' => 'encryption_profile_1',
+      'label' => 'Encryption profile 1',
+      'encryption_method' => 'test_encryption_method',
+      'encryption_key' => $this->testKeys['testing_key_128']->id(),
+    ]);
+    $encryption_profile_1->save();
+    $this->encryptionProfiles['encryption_profile_1'] = $encryption_profile_1;
+
+    $encryption_profile_2 = EncryptionProfile::create([
+      'id' => 'encryption_profile_2',
+      'label' => 'Encryption profile 2',
+      'encryption_method' => 'config_test_encryption_method',
+      'encryption_method_configuration' => ['mode' => 'CFB'],
+      'encryption_key' => $this->testKeys['testing_key_256']->id(),
+    ]);
+    $encryption_profile_2->save();
+    $this->encryptionProfiles['encryption_profile_2'] = $encryption_profile_2;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->createTestKeys();
+    $this->createTestEncryptionProfiles();
+  }
+
+  public function testFieldStorageSettingsForm() {
+    $account = $this->drupalCreateUser([
+      'administer content types',
+      'administer node fields',
+      'administer node display',
+    ]);
+    $this->drupalLogin($account);
+
+    NodeType::create([
+      'type' => 'page',
+    ])->save();
+
+    $assert = $this->assertSession();
+    $this->drupalGet('admin/structure/types/manage/page/fields/add-field');
+    $assert->statusCodeEquals(200);
+
+    $this->submitForm([
+      'new_storage_type' => 'file',
+      'field_name' => 'test_file',
+      'label' => 'New file field',
+    ], 'Save and continue');
+
+    file_put_contents('/tmp/foo.html', $this->getSession()->getPage()->getHtml());
+
+    $this->submitForm([
+      'settings[uri_scheme]' => 'encrypt',
+      'settings[encryption_profile]' => 'encryption_profile_1',
+    ], 'Save field settings');
+
+    $field_storage_config = FieldStorageConfig::load('node.field_test_file');
+    $this->assertEquals('encryption_profile_1', $field_storage_config->getThirdPartySetting('file_encrypt', 'encryption_profile'));
+  }
+
+}

--- a/tests/src/Functional/FieldStorageConfigurationTest.php
+++ b/tests/src/Functional/FieldStorageConfigurationTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\file_encrypt\Functional;
 
 use Drupal\encrypt\Entity\EncryptionProfile;
+use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\key\Entity\Key;
 use Drupal\node\Entity\NodeType;
@@ -129,6 +130,9 @@ class FieldStorageConfigurationTest extends BrowserTestBase {
     $field_storage_config = FieldStorageConfig::load('node.field_test_file');
     $this->assertEquals('encryption_profile_1', $field_storage_config->getThirdPartySetting('file_encrypt', 'encryption_profile'));
 
+    $field_config = FieldConfig::load('node.page.field_test_file');
+    $this->assertStringStartsWith('encryption_profile_1', $field_config->getSetting('file_directory'));
+
     // Test an image field.
     $this->drupalGet('admin/structure/types/manage/page/fields/add-field');
     $assert->statusCodeEquals(200);
@@ -146,6 +150,9 @@ class FieldStorageConfigurationTest extends BrowserTestBase {
 
     $field_storage_config = FieldStorageConfig::load('node.field_test_image');
     $this->assertEquals('encryption_profile_1', $field_storage_config->getThirdPartySetting('file_encrypt', 'encryption_profile'));
+
+    $field_config = FieldConfig::load('node.page.field_test_file');
+    $this->assertStringStartsWith('encryption_profile_1', $field_config->getSetting('file_directory'));
   }
 
 }

--- a/tests/src/Functional/FileUploadTest.php
+++ b/tests/src/Functional/FileUploadTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Drupal\Tests\file_encrypt\Functional;
+
+use Drupal\Core\StreamWrapper\PublicStream;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\file\Entity\File;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+
+/**
+ * Tests uploading files as well as viewing files on the rendered entity.
+ *
+ * @group file_encrypt
+ */
+class FileUploadTest extends FunctionalTestBase {
+
+  /**
+   * @var boolean
+   */
+  protected $generatedTestFiles;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    NodeType::create([
+      'type' => 'page',
+    ])->save();
+
+    FieldStorageConfig::create([
+      'entity_type' => 'node',
+      'field_name' => 'field_test_file',
+      'type' => 'file',
+      'settings' => [
+        'uri_scheme' => 'encrypt',
+      ],
+      'third_party_settings' => [
+        'file_encrypt' => [
+          'encryption_profile' => 'encryption_profile_1',
+        ],
+      ],
+    ])->save();
+
+    FieldConfig::create([
+      'entity_type' => 'node',
+      'field_name' => 'field_test_file',
+      'bundle' => 'page',
+      'settings' => [
+        'file_directory' => 'encryption_profile_1',
+        'file_extensions' => 'txt',
+      ],
+    ])->save();
+
+    $this->drupalGetTestFiles('text');
+
+    $form_display = entity_get_form_display('node', 'page', 'default');
+    $form_display->setComponent('field_test_file', [
+      'type' => 'file_generic',
+    ]);
+    $form_display->save();
+
+    $view_display = entity_get_display('node', 'page', 'default');
+    $view_display->setComponent('field_test_file', [
+      'type' => 'file_url_plain',
+    ]);
+    $view_display->save();
+  }
+
+  /**
+   * Tests uploading an actual file.
+   */
+  public function testFileUpload() {
+    $account = $this->drupalCreateUser(['create page content']);
+    $this->drupalLogin($account);
+
+    $text_files = $this->drupalGetTestFiles('text');
+    $text_file = File::create((array) current($text_files));
+    $text_file->getFileUri();
+
+    $assert = $this->assertSession();
+    $this->drupalGet('node/add/page');
+    $assert->statusCodeEquals(200);
+    $edit = [
+      'title[0][value]' => 'Test title',
+      'files[field_test_file_0]' => drupal_realpath($text_file->getFileUri()),
+    ];
+    $this->submitForm($edit, 'Save');
+
+    // Ensure the file was saved.
+    $nodes = Node::loadMultiple();
+    $this->assertCount(1, $nodes);
+    $last_node = end($nodes);
+    $this->assertEquals('encrypt://encryption_profile_1/text-0_0.txt', $last_node->field_test_file->entity->getFileUri());
+  
+    // Ensure the file was visible.
+    file_put_contents('/tmp/foo.html', $this->getSession()->getPage()->getHtml());
+    $assert->pageTextContains('/encrypt/files?file=encryption_profile_1/text-0_0.txt');
+  }
+
+  /**
+   * Gets a list of files that can be used in tests.
+   *
+   * The first time this method is called, it will call
+   * simpletest_generate_file() to generate binary and ASCII text files in the
+   * public:// directory. It will also copy all files in
+   * core/modules/simpletest/files to public://. These contain image, SQL, PHP,
+   * JavaScript, and HTML files.
+   *
+   * All filenames are prefixed with their type and have appropriate extensions:
+   * - text-*.txt
+   * - binary-*.txt
+   * - html-*.html and html-*.txt
+   * - image-*.png, image-*.jpg, and image-*.gif
+   * - javascript-*.txt and javascript-*.script
+   * - php-*.txt and php-*.php
+   * - sql-*.txt and sql-*.sql
+   *
+   * Any subsequent calls will not generate any new files, or copy the files
+   * over again. However, if a test class adds a new file to public:// that
+   * is prefixed with one of the above types, it will get returned as well, even
+   * on subsequent calls.
+   *
+   * @param $type
+   *   File type, possible values: 'binary', 'html', 'image', 'javascript',
+   *   'php', 'sql', 'text'.
+   * @param $size
+   *   (optional) File size in bytes to match. Defaults to NULL, which will not
+   *   filter the returned list by size.
+   *
+   * @return
+   *   List of files in public:// that match the filter(s).
+   */
+  protected function drupalGetTestFiles($type, $size = NULL) {
+    if (empty($this->generatedTestFiles)) {
+      // Generate binary test files.
+      $lines = array(64, 1024);
+      $count = 0;
+      foreach ($lines as $line) {
+        simpletest_generate_file('binary-' . $count++, 64, $line, 'binary');
+      }
+
+      // Generate ASCII text test files.
+      $lines = array(16, 256, 1024, 2048, 20480);
+      $count = 0;
+      foreach ($lines as $line) {
+        simpletest_generate_file('text-' . $count++, 64, $line, 'text');
+      }
+
+      // Copy other test files from simpletest.
+      $original = drupal_get_path('module', 'simpletest') . '/files';
+      $files = file_scan_directory($original, '/(html|image|javascript|php|sql)-.*/');
+      foreach ($files as $file) {
+        file_unmanaged_copy($file->uri, PublicStream::basePath());
+      }
+
+      $this->generatedTestFiles = TRUE;
+    }
+
+    $files = array();
+    // Make sure type is valid.
+    if (in_array($type, array('binary', 'html', 'image', 'javascript', 'php', 'sql', 'text'))) {
+      $files = file_scan_directory('public://', '/' . $type . '\-.*/');
+
+      // If size is set then remove any files that are not of that size.
+      if ($size !== NULL) {
+        foreach ($files as $file) {
+          $stats = stat($file->uri);
+          if ($stats['size'] != $size) {
+            unset($files[$file->uri]);
+          }
+        }
+      }
+    }
+    usort($files, array($this, 'drupalCompareFiles'));
+    return $files;
+  }
+
+  /**
+   * Compare two files based on size and file name.
+   */
+  protected function drupalCompareFiles($file1, $file2) {
+    $compare_size = filesize($file1->uri) - filesize($file2->uri);
+    if ($compare_size) {
+      // Sort by file size.
+      return $compare_size;
+    }
+    else {
+      // The files were the same size, so sort alphabetically.
+      return strnatcmp($file1->name, $file2->name);
+    }
+  }
+
+}

--- a/tests/src/Functional/FileUploadTest.php
+++ b/tests/src/Functional/FileUploadTest.php
@@ -131,7 +131,7 @@ class FileUploadTest extends FunctionalTestBase {
    *   (optional) File size in bytes to match. Defaults to NULL, which will not
    *   filter the returned list by size.
    *
-   * @return
+   * @return \Drupal\file\Entity\File[]
    *   List of files in public:// that match the filter(s).
    */
   protected function drupalGetTestFiles($type, $size = NULL) {

--- a/tests/src/Functional/FunctionalTestBase.php
+++ b/tests/src/Functional/FunctionalTestBase.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Drupal\Tests\file_encrypt\Functional;
+
+use Drupal\encrypt\Entity\EncryptionProfile;
+use Drupal\key\Entity\Key;
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Base test class for all kind of file encrypt tests.
+ */
+abstract class FunctionalTestBase extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = ['file_encrypt', 'encrypt', 'key', 'encrypt_test', 'node', 'file', 'field_ui', 'image'];
+
+  /**
+   * A list of testkeys.
+   *
+   * @var \Drupal\key\Entity\Key[]
+   */
+  protected $testKeys;
+
+  /**
+   * A list of test encryption profiles.
+   *
+   * @var \Drupal\encrypt\Entity\EncryptionProfile[]
+   */
+  protected $encryptionProfiles;
+
+  /**
+   * Creates test keys for usage in tests.
+   */
+  protected function createTestKeys() {
+    // Create a 128bit testkey.
+    $key_128 = Key::create([
+      'id' => 'testing_key_128',
+      'label' => 'Testing Key 128 bit',
+      'key_type' => "encryption",
+      'key_type_settings' => ['key_size' => '128'],
+      'key_provider' => 'config',
+      'key_provider_settings' => ['key_value' => 'mustbesixteenbit'],
+    ]);
+    $key_128->save();
+    $this->testKeys['testing_key_128'] = $key_128;
+
+    // Create a 256bit testkey.
+    $key_256 = Key::create([
+      'id' => 'testing_key_256',
+      'label' => 'Testing Key 256 bit',
+      'key_type' => "encryption",
+      'key_type_settings' => ['key_size' => '256'],
+      'key_provider' => 'config',
+      'key_provider_settings' => ['key_value' => 'mustbesixteenbitmustbesixteenbit'],
+    ]);
+    $key_256->save();
+    $this->testKeys['testing_key_256'] = $key_256;
+  }
+
+  /**
+   * Creates test encryption profiles for usage in tests.
+   */
+  protected function createTestEncryptionProfiles() {
+    // Create test encryption profiles.
+    $encryption_profile_1 = EncryptionProfile::create([
+      'id' => 'encryption_profile_1',
+      'label' => 'Encryption profile 1',
+      'encryption_method' => 'test_encryption_method',
+      'encryption_key' => $this->testKeys['testing_key_128']->id(),
+    ]);
+    $encryption_profile_1->save();
+    $this->encryptionProfiles['encryption_profile_1'] = $encryption_profile_1;
+
+    $encryption_profile_2 = EncryptionProfile::create([
+      'id' => 'encryption_profile_2',
+      'label' => 'Encryption profile 2',
+      'encryption_method' => 'config_test_encryption_method',
+      'encryption_method_configuration' => ['mode' => 'CFB'],
+      'encryption_key' => $this->testKeys['testing_key_256']->id(),
+    ]);
+    $encryption_profile_2->save();
+    $this->encryptionProfiles['encryption_profile_2'] = $encryption_profile_2;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->createTestKeys();
+    $this->createTestEncryptionProfiles();
+  }
+
+}

--- a/tests/src/Functional/FunctionalTestBase.php
+++ b/tests/src/Functional/FunctionalTestBase.php
@@ -92,6 +92,15 @@ abstract class FunctionalTestBase extends BrowserTestBase {
 
     $this->createTestKeys();
     $this->createTestEncryptionProfiles();
+
+    $this->writeSettings([
+      'settings' => [
+        'encrypted_file_path' => (object) [
+            'value' => $this->publicFilesDirectory,
+            'required' => TRUE,
+        ],
+      ],
+    ]);
   }
 
 }


### PR DESCRIPTION
This PR is build upon #3

This PR allows you to
- Select "encrypt" on file field field storage settings.
- Select an encryption profile on the same page
- Automatically configure the right upload location for those files
- Actually upload the file
- See the actual file on the node itself.

This PR also adds test coverage for
- Creating and configuring fields
- Encrypting file fields

TODO:
- Preview doesn't show the actual image yet [I think this should tackled in a follow up]
