### PR TITLE
Fix encrypted files not downloading properly due to incorrect Content-Length header value

### DIFF
--- a/file_encrypt.routing.yml
+++ b/file_encrypt.routing.yml
@@ -1,7 +1,7 @@
 file_encrypt.file_download:
   path: '/encrypt/files'
   defaults:
-    _controller: \Drupal\system\FileDownloadController::download
+    _controller: 'Drupal\file_encrypt\Controller\FileDownloadController::download'
     scheme: encrypt
   requirements:
     _access: 'TRUE'

--- a/src/Controller/FileDownloadController.php
+++ b/src/Controller/FileDownloadController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\file_encrypt\Controller;
+
+use Drupal\file_encrypt\EncryptBinaryFileResponse;
+use Drupal\system\FileDownloadController as CoreFileDownloadController;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Provides route responses for encrypted file downloads.
+ */
+class FileDownloadController extends CoreFileDownloadController {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function download(Request $request, $scheme = 'encrypt') {
+    $response = parent::download($request, $scheme);
+    return new EncryptBinaryFileResponse($response->getFile(), 200, $response->headers->all(), FALSE);
+  }
+
+}

--- a/src/Controller/ImageStyleDownloadController.php
+++ b/src/Controller/ImageStyleDownloadController.php
@@ -6,7 +6,6 @@ use Drupal\Component\Utility\Crypt;
 use Drupal\Core\Image\ImageFactory;
 use Drupal\Core\Lock\LockBackendInterface;
 use Drupal\image\ImageStyleInterface;
-use Drupal\system\FileDownloadController;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;

--- a/src/EncryptBinaryFileResponse.php
+++ b/src/EncryptBinaryFileResponse.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Drupal\file_encrypt;
+
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class EncryptBinaryFileResponse extends BinaryFileResponse  {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function prepare(Request $request) {
+    parent::prepare($request);
+    $this->fixContentLengthHeader();
+    $this->setPrivate();
+    return $this;
+  }
+
+  /**
+   * Fixes the Content-Length response header.
+   *
+   * This works around a bug in symfony/http-foundation that causes
+   * BinaryFileResponse to send the wrong Content-Length header value for files
+   * modified by stream filters as encrypted files are. See
+   * https://github.com/symfony/symfony/issues/19738.
+   */
+  protected function fixContentLengthHeader() {
+    $file = fopen($this->getFile()->getPathname(), 'rb');
+    $this->headers->set('Content-Length', fstat($file)['size']);
+    fclose($file);
+  }
+
+}


### PR DESCRIPTION
Fixes #20.
